### PR TITLE
feat: add git worktree indicator to statusline

### DIFF
--- a/plugin/bin/starship-claude
+++ b/plugin/bin/starship-claude
@@ -12,6 +12,7 @@
 # - `CLAUDE_COST` - Formatted session cost (e.g., "$0.71")
 # - `CLAUDE_SUMMARY` - Session summary extracted from transcript
 # - `CLAUDE_STAR` - Star character for prompt decoration
+# - `CLAUDE_WORKTREE` - Git worktree name (only set when in a worktree, cached)
 #
 # Raw values (direct from JSON):
 # - `CLAUDE_SESSION_ID` - Session UUID
@@ -296,6 +297,34 @@ if command -v jq >/dev/null 2>&1 && [ -n "$payload" ]; then
     fi
   else
     export CLAUDE_CONTEXT="  %"
+  fi
+
+  #
+  # Git worktree detection (cached to avoid repeated git calls per render)
+  #
+  _worktree_cache_dir="${TMPDIR:-/tmp}/starship-claude-cache"
+  mkdir -p "$_worktree_cache_dir" 2>/dev/null || true
+  _wt_cache_key="$(printf '%s' "$PWD" | cksum | cut -d' ' -f1)"
+  _wt_cache_file="$_worktree_cache_dir/wt_$_wt_cache_key"
+  _wt_cache_ttl=300  # 5 minutes
+
+  _wt_value=""
+  if [ -f "$_wt_cache_file" ] && \
+     [ "$(( $(date +%s) - $(stat -f%m "$_wt_cache_file" 2>/dev/null || stat -c%Y "$_wt_cache_file" 2>/dev/null || echo 0) ))" -lt "$_wt_cache_ttl" ]; then
+    _wt_value="$(cat "$_wt_cache_file")"
+  else
+    _git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
+    _git_common="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+    if [ -n "$_git_dir" ] && [ -n "$_git_common" ] && [ "$_git_dir" != "$_git_common" ]; then
+      _wt_value="${PWD##*/}"
+    fi
+    printf '%s' "$_wt_value" > "$_wt_cache_file" 2>/dev/null || true
+  fi
+
+  if [ -n "$_wt_value" ]; then
+    export CLAUDE_WORKTREE="$_wt_value"
+  else
+    unset CLAUDE_WORKTREE 2>/dev/null || true
   fi
 fi
 

--- a/plugin/templates/bubbles.toml
+++ b/plugin/templates/bubbles.toml
@@ -9,6 +9,7 @@ format = """
 [](directory_bg)\
 ${env_var.CLAUDE_STAR}\
 $directory\
+${env_var.CLAUDE_WORKTREE}\
 [](fg:git_bg bg:directory_bg)\
 $git_branch\
 $git_status\
@@ -41,6 +42,11 @@ format = "[$symbol $branch]($style)"
 [git_status]
 style = "bg:git_bg fg:git_status"
 format = "[($all_status$ahead_behind)]($style)"
+
+[env_var.CLAUDE_WORKTREE]
+variable = "CLAUDE_WORKTREE"
+format = "[ $env_value]($style)"
+style = "bg:directory_bg fg:worktree"
 
 [env_var.CLAUDE_MODEL_NERD]
 variable = "CLAUDE_MODEL_NERD"

--- a/plugin/templates/minimal-nerd.toml
+++ b/plugin/templates/minimal-nerd.toml
@@ -4,9 +4,10 @@
 palette = "custom"
 add_newline = false
 
-# dir git model context cost
+# dir [worktree] git model context cost
 format = """
-$directory \
+$directory\
+${env_var.CLAUDE_WORKTREE} \
 $git_branch$git_status \
 ${env_var.CLAUDE_MODEL_NERD} \
 ${env_var.CLAUDE_CONTEXT} \
@@ -27,6 +28,11 @@ format = "[$branch]($style)"
 [git_status]
 style = "fg:git_status"
 format = "[($all_status$ahead_behind)]($style)"
+
+[env_var.CLAUDE_WORKTREE]
+variable = "CLAUDE_WORKTREE"
+format = "[ $env_value]($style)"
+style = "fg:worktree"
 
 [env_var.CLAUDE_MODEL_NERD]
 variable = "CLAUDE_MODEL_NERD"

--- a/plugin/templates/minimal-text.toml
+++ b/plugin/templates/minimal-text.toml
@@ -4,9 +4,10 @@
 palette = "custom"
 add_newline = false
 
-# dir git model context cost
+# dir [worktree] git model context cost
 format = """
-$directory \
+$directory\
+${env_var.CLAUDE_WORKTREE} \
 $git_branch$git_status \
 ${env_var.CLAUDE_MODEL} \
 ${env_var.CLAUDE_CONTEXT} \
@@ -27,6 +28,11 @@ format = "[$branch]($style)"
 [git_status]
 style = "fg:git_status"
 format = "[($all_status$ahead_behind)]($style)"
+
+[env_var.CLAUDE_WORKTREE]
+variable = "CLAUDE_WORKTREE"
+format = "[ $env_value]($style)"
+style = "fg:worktree"
 
 [env_var.CLAUDE_MODEL]
 variable = "CLAUDE_MODEL"

--- a/plugin/templates/palettes/catppuccin_frappe.toml
+++ b/plugin/templates/palettes/catppuccin_frappe.toml
@@ -45,3 +45,5 @@ context_bg = "#ccd0da"
 
 cost = "#40a02b"
 cost_bg = "#bcc0cc"
+
+worktree = "#df8e1d"

--- a/plugin/templates/palettes/catppuccin_mocha.toml
+++ b/plugin/templates/palettes/catppuccin_mocha.toml
@@ -20,3 +20,5 @@ context_bg = "#313244"
 
 cost = "#a6e3a1"
 cost_bg = "#45475a"
+
+worktree = "#f9e2af"

--- a/plugin/templates/palettes/dracula.toml
+++ b/plugin/templates/palettes/dracula.toml
@@ -18,3 +18,5 @@ context_bg = "#44475a"
 
 cost = "#50fa7b"
 cost_bg = "#4d4f68"
+
+worktree = "#f1fa8c"

--- a/plugin/templates/palettes/gruvbox_dark.toml
+++ b/plugin/templates/palettes/gruvbox_dark.toml
@@ -18,3 +18,5 @@ context_bg = "#3c3836"
 
 cost = "#689d6a"
 cost_bg = "#504945"
+
+worktree = "#fabd2f"

--- a/plugin/templates/palettes/nord.toml
+++ b/plugin/templates/palettes/nord.toml
@@ -18,3 +18,5 @@ context_bg = "#3b4252"
 
 cost = "#a3be8c"
 cost_bg = "#434c5e"
+
+worktree = "#ebcb8b"

--- a/plugin/templates/palettes/tokyonight.toml
+++ b/plugin/templates/palettes/tokyonight.toml
@@ -45,3 +45,5 @@ context_bg = "#1d2230"
 cost = "#c0caf5"
 cost_bg = "#394260"
 
+worktree = "#e0af68"
+

--- a/plugin/templates/powerline.toml
+++ b/plugin/templates/powerline.toml
@@ -9,6 +9,7 @@ format = """
 ${env_var.CLAUDE_STAR}\
 [](bg:directory_bg fg:claude_bg)\
 $directory\
+${env_var.CLAUDE_WORKTREE}\
 [](fg:directory_bg bg:git_bg)\
 $git_branch\
 $git_status\
@@ -40,6 +41,11 @@ format = "[ $symbol $branch]($style)"
 [git_status]
 style = "bg:git_bg fg:git_status"
 format = "[($all_status$ahead_behind)]($style)"
+
+[env_var.CLAUDE_WORKTREE]
+variable = "CLAUDE_WORKTREE"
+format = "[ $env_value]($style)"
+style = "bg:directory_bg fg:worktree"
 
 [env_var.CLAUDE_MODEL_NERD]
 variable = "CLAUDE_MODEL_NERD"

--- a/starship-claude
+++ b/starship-claude
@@ -12,6 +12,7 @@
 # - `CLAUDE_COST` - Formatted session cost (e.g., "$0.71")
 # - `CLAUDE_SUMMARY` - Session summary extracted from transcript
 # - `CLAUDE_STAR` - Star character for prompt decoration
+# - `CLAUDE_WORKTREE` - Git worktree name (only set when in a worktree, cached)
 #
 # Raw values (direct from JSON):
 # - `CLAUDE_SESSION_ID` - Session UUID
@@ -296,6 +297,34 @@ if command -v jq >/dev/null 2>&1 && [ -n "$payload" ]; then
     fi
   else
     export CLAUDE_CONTEXT="  %"
+  fi
+
+  #
+  # Git worktree detection (cached to avoid repeated git calls per render)
+  #
+  _worktree_cache_dir="${TMPDIR:-/tmp}/starship-claude-cache"
+  mkdir -p "$_worktree_cache_dir" 2>/dev/null || true
+  _wt_cache_key="$(printf '%s' "$PWD" | cksum | cut -d' ' -f1)"
+  _wt_cache_file="$_worktree_cache_dir/wt_$_wt_cache_key"
+  _wt_cache_ttl=300  # 5 minutes
+
+  _wt_value=""
+  if [ -f "$_wt_cache_file" ] && \
+     [ "$(( $(date +%s) - $(stat -f%m "$_wt_cache_file" 2>/dev/null || stat -c%Y "$_wt_cache_file" 2>/dev/null || echo 0) ))" -lt "$_wt_cache_ttl" ]; then
+    _wt_value="$(cat "$_wt_cache_file")"
+  else
+    _git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
+    _git_common="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+    if [ -n "$_git_dir" ] && [ -n "$_git_common" ] && [ "$_git_dir" != "$_git_common" ]; then
+      _wt_value="${PWD##*/}"
+    fi
+    printf '%s' "$_wt_value" > "$_wt_cache_file" 2>/dev/null || true
+  fi
+
+  if [ -n "$_wt_value" ]; then
+    export CLAUDE_WORKTREE="$_wt_value"
+  else
+    unset CLAUDE_WORKTREE 2>/dev/null || true
   fi
 fi
 

--- a/starship.toml
+++ b/starship.toml
@@ -4,7 +4,8 @@ add_newline = false
 
 # Minimal style - clean and simple
 format = """
-$directory \
+$directory\
+${env_var.CLAUDE_WORKTREE} \
 $git_branch$git_status \
 ${env_var.CLAUDE_MODEL} \
 ${env_var.CLAUDE_CONTEXT} \
@@ -25,6 +26,11 @@ format = "[$branch]($style)"
 [git_status]
 style = "fg:maroon"
 format = "[($all_status$ahead_behind)]($style)"
+
+[env_var.CLAUDE_WORKTREE]
+variable = "CLAUDE_WORKTREE"
+format = "[ $env_value]($style)"
+style = "fg:yellow"
 
 [env_var.CLAUDE_MODEL]
 variable = "CLAUDE_MODEL"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -34,6 +34,7 @@ printf "CLAUDE_CONTEXT=%s\n" "${CLAUDE_CONTEXT:-}"
 printf "CLAUDE_SUMMARY=%s\n" "${CLAUDE_SUMMARY:-}"
 printf "CLAUDE_CURRENT_TOKENS=%s\n" "${CLAUDE_CURRENT_TOKENS:-}"
 printf "CLAUDE_PERCENT_RAW=%s\n" "${CLAUDE_PERCENT_RAW:-}"
+printf "CLAUDE_WORKTREE=%s\n" "${CLAUDE_WORKTREE:-}"
 
 # Raw session/workspace values
 printf "CLAUDE_SESSION_ID=%s\n" "${CLAUDE_SESSION_ID:-}"

--- a/test/worktree_detection.bats
+++ b/test/worktree_detection.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Tests for git worktree detection and caching
+
+bats_require_minimum_version 1.5.0
+load test_helper
+
+@test "worktree: CLAUDE_WORKTREE is empty in normal repo" {
+  output=$(run_with_fixture "active_session_with_context.json")
+  assert_env_empty "CLAUDE_WORKTREE" "$output"
+}
+
+@test "worktree: cache directory is created" {
+  run_with_fixture "active_session_with_context.json" >/dev/null 2>&1
+  cache_dir="${TMPDIR:-/tmp}/starship-claude-cache"
+  [ -d "$cache_dir" ]
+}
+
+@test "worktree: cache file is created for current directory" {
+  run_with_fixture "active_session_with_context.json" >/dev/null 2>&1
+  cache_dir="${TMPDIR:-/tmp}/starship-claude-cache"
+  # At least one cache file should exist
+  [ -n "$(ls "$cache_dir"/wt_* 2>/dev/null)" ]
+}


### PR DESCRIPTION
## Summary
- Adds `CLAUDE_WORKTREE` env var that is set to the worktree directory name when running inside a git worktree, and unset otherwise (so the starship module is hidden in normal repos)
- Worktree detection is **cached** per directory (5-minute TTL) to avoid repeated `git rev-parse` calls on every statusline render
- Cache uses `cksum` of `$PWD` as key and supports both macOS (`stat -f%m`) and Linux (`stat -c%Y`)
- All 4 templates updated with the worktree module (displayed between directory and git branch)
- All 6 palettes updated with a `worktree` color (yellow/amber accent matching each theme)
- Test helper updated + new `worktree_detection.bats` test file

## Motivation
When using Claude Code with git worktrees (common for parallel feature work), there is no visual indicator of which worktree you are in. The git branch module shows the branch name, but an explicit worktree label makes it immediately clear.

## How it works
1. After `cd` into the workspace dir, compares `git rev-parse --git-dir` vs `--git-common-dir`
2. If they differ → we are in a worktree → export `CLAUDE_WORKTREE` with the directory basename
3. If equal → normal repo → `unset CLAUDE_WORKTREE` (starship hides the module)
4. Result is cached to `$TMPDIR/starship-claude-cache/wt_<cksum>` for 5 minutes

## Test plan
- [ ] Verify worktree indicator is hidden in normal repos
- [ ] Verify worktree indicator shows correct name in a git worktree
- [ ] Verify cache file is created and reused within TTL
- [ ] Run existing tests to ensure no regressions
- [ ] Test on both macOS and Linux (stat flag differences)