### PR TITLE
feat: add earth-night palette

### DIFF
--- a/plugin/templates/palettes/earth_night.toml
+++ b/plugin/templates/palettes/earth_night.toml
@@ -1,0 +1,46 @@
+# Earth Night
+[palettes.custom]
+# Default colors
+background = '#2a211a'
+foreground = '#e8dfd5'
+
+# Normal colors
+black = '#1a1310'
+red = '#c47a5a'
+green = '#8a9a6b'
+yellow = '#c4a882'
+blue = '#8a6e4e'
+purple = '#9a7b6a'
+cyan = '#7a9a8a'
+white = '#d4c8b8'
+
+# Bright colors
+bright-black = '#5c4333'
+bright-red = '#d49070'
+bright-green = '#9aaa7b'
+bright-yellow = '#d4b892'
+bright-blue = '#9a7e5e'
+bright-purple = '#aa8b7a'
+bright-cyan = '#8aaa9a'
+bright-white = '#e8dfd5'
+
+
+# Semantic colors for templates
+claude = "#090c0c"
+claude_bg = "#c4a882"
+
+directory = "#e8dfd5"
+directory_bg = "#8a6e4e"
+
+git_branch = "#c4a882"
+git_status = "#c4a882"
+git_bg = "#5c4333"
+
+model = "#c4a882"
+model_bg = "#3a2a1c"
+
+context = "#b8a898"
+context_bg = "#241a10"
+
+cost = "#e8dfd5"
+cost_bg = "#5c4333"


### PR DESCRIPTION
## Summary
- Adds **earth-night** palette for the powerline template
- Warm brown/tan/olive tones — earthy counterpart to the tokyonight palette
- Includes both base terminal colors and semantic colors for templates

## Color Highlights
| Semantic Role | Color | Hex |
|---------------|-------|-----|
| Claude star bg | Warm tan | `#c4a882` |
| Directory bg | Saddle brown | `#8a6e4e` |
| Git bg | Medium brown | `#5c4333` |
| Model bg | Dark brown | `#3a2a1c` |
| Context bg | Darkest brown | `#241a10` |

Recommended terminal background: `#2a211a`

## Related
- Companion preset PR in starship/starship: https://github.com/starship/starship/pull/7316